### PR TITLE
Fixed CheckAge check on archive and delete age

### DIFF
--- a/arki/dataset/ondisk2/writer.cc
+++ b/arki/dataset/ondisk2/writer.cc
@@ -342,12 +342,12 @@ void CheckAge::operator()(const std::string& file, data::FileState state)
     {
         string maxdate = idx.max_file_reftime(file);
         //cerr << "TEST " << maxdate << " WITH " << delete_threshold << " AND " << archive_threshold << endl;
-        if (delete_threshold >= maxdate)
+        if (not delete_threshold.empty() && delete_threshold >= maxdate)
         {
             nag::verbose("CheckAge: %s is old enough to be deleted", file.c_str());
             next(file, state + FILE_TO_DELETE);
         }
-        else if (archive_threshold >= maxdate)
+        else if (not archive_threshold.empty() && archive_threshold >= maxdate)
         {
             nag::verbose("CheckAge: %s is old enough to be archived", file.c_str());
             next(file, state + FILE_TO_ARCHIVE);


### PR DESCRIPTION
When delete (or archive) age is unset (but not both) the test against maxdate should be skipped.

This implementation is useful only when the file is not in the index (`maxdate` is empty).