### PR TITLE
reftime lexer and parser in dist

### DIFF
--- a/arki/Makefile.am
+++ b/arki/Makefile.am
@@ -171,17 +171,16 @@ nobase_dist_arkiinclude_HEADERS = \
 		utils/net/http.h \
 		values.h
 
-BUILT_SOURCES = $(top_builddir)/arki/matcher/reftime/reftime-lex.h \
-		$(top_builddir)/arki/matcher/reftime/reftime-lex.cc \
-		$(top_builddir)/arki/matcher/reftime/reftime-parse.hh \
-		$(top_builddir)/arki/matcher/reftime/reftime-parse.cc
+BUILT_SOURCES = \
+		$(srcdir)/matcher/reftime/reftime-lex.h \
+		$(srcdir)/matcher/reftime/reftime-lex.cc \
+		$(srcdir)/matcher/reftime/reftime-parse.hh \
+		$(srcdir)/matcher/reftime/reftime-parse.cc
 
-all_built_sources: $(BUILT_SOURCES)
-
-$(top_builddir)/arki/matcher/reftime/reftime-lex.h $(top_builddir)/arki/matcher/reftime/reftime-lex.cc: $(srcdir)/matcher/reftime/reftime-lex.ll
+$(srcdir)/matcher/reftime/reftime-lex.h $(srcdir)/matcher/reftime/reftime-lex.cc: $(srcdir)/matcher/reftime/reftime-lex.ll
 	$(srcdir)/buildflex $<
 
-$(top_builddir)/arki/matcher/reftime/reftime-parse.hh $(top_builddir)/arki/matcher/reftime/reftime-parse.cc: $(srcdir)/matcher/reftime/reftime-parse.yy
+$(srcdir)/matcher/reftime/reftime-parse.hh $(srcdir)/matcher/reftime/reftime-parse.cc: $(srcdir)/matcher/reftime/reftime-parse.yy
 	$(srcdir)/buildbison $<
 
 lib_LTLIBRARIES = libarkimet.la
@@ -618,5 +617,7 @@ tests_arki_test_LDADD += libarkimet.la $(SQLITE3_LDFLAGS) $(DEVEL_LIBS) -lpthrea
 EXTRA_DIST = runtest buildbison buildflex \
 	     matcher/reftime/reftime-lex.ll \
 	     matcher/reftime/reftime-parse.yy \
-	     $(top_builddir)/arki/matcher/reftime/reftime-lex.h \
-	     $(top_builddir)/arki/matcher/reftime/reftime-parse.hh
+	     $(srcdir)/matcher/reftime/reftime-lex.h \
+	     $(srcdir)/matcher/reftime/reftime-lex.cc \
+	     $(srcdir)/matcher/reftime/reftime-parse.hh \
+	     $(srcdir)/matcher/reftime/reftime-parse.cc


### PR DESCRIPTION
Fix #15 (`make` before `make dist` is no more needed).

Source and header files for lexer and parser should be included in distribution (see https://www.gnu.org/software/automake/manual/html_node/Yacc-and-Lex.html). The standard way to include these files doesn't work in this case (lexer and parser in subdir + header file for lexer), so the behaviour of `ylwrap` is "emulated".

The right solution would be:
```
AM_YFLAGS = -d
AM_LFLAGS = --header-file=matcher/reftime/reftime-lex.h
libarkimet_la_SOURCES = \
     ... \
     matcher/reftime/reftime-lex.ll \
     matcher/reftime/reftime-parse.yy \
     ...

BUILT_SOURCES = \
    matcher/reftime/reftime-lex.h \
    matcher/reftime/reftime-parse.h
```

But `ylwrap` doesn't handle subdirectories (the files are created in `.` instead of `matcher/reftime`) and doesn't add `reftime-lex.h` to the dist tar.