### PR TITLE
Destroy Segment object after use (fix #82)

### DIFF
--- a/arki/dataset/segment/fd.cc
+++ b/arki/dataset/segment/fd.cc
@@ -445,9 +445,6 @@ Pending Segment::repack(
         (*i)->drop_cached_data();
     }
 
-    // Close the temp file
-    writer.release();
-
     return p;
 }
 


### PR DESCRIPTION
The memory leak and the unclosed fds are fixed (fix #82).