### PR TITLE
Better HTTP status code handling

### DIFF
--- a/python/arkimet/server/views.py
+++ b/python/arkimet/server/views.py
@@ -9,7 +9,7 @@ from urllib.parse import quote
 from contextlib import contextmanager
 import logging
 import arkimet as arki
-from werkzeug.exceptions import HTTPException, NotFound
+from werkzeug.exceptions import NotFound
 
 
 class ArkiView:
@@ -101,7 +101,9 @@ class ArkiView:
         if not self.headers_sent:
             logging.exception("Exception caught before headers have been sent")
             ex = sys.exc_info()[1]
-            self.handler.send_response(500)
+            # If the exception has code attribute, use for the status code
+            code = getattr(ex, "code", 500)
+            self.handler.send_response(code)
             self.handler.send_header("Content-Type", "text/plain")
             self.handler.send_header("Arkimet-Exception", str(ex))
             self.handler.end_headers()
@@ -123,8 +125,6 @@ class ArkiView:
             self.stream()
             if not self.headers_sent:
                 self.send_headers()
-        except HTTPException as e:
-            raise e
         except Exception:
             self.handle_exception()
         self.log_end()
@@ -277,8 +277,6 @@ class TempdirMixin:
                 self.stream()
                 if not self.headers_sent:
                     self.send_headers()
-        except HTTPException as e:
-            raise e
         except Exception:
             self.handle_exception()
         finally:

--- a/python/arkimet/server/views.py
+++ b/python/arkimet/server/views.py
@@ -490,6 +490,7 @@ class ArkiDatasetIndex(ArkiView):
 
     def stream(self):
         name = self.kwargs["name"]
+        cfg = self.get_dataset_config()
 
 #        // Query the summary
 #        Summary sum;
@@ -502,7 +503,7 @@ class ArkiDatasetIndex(ArkiView):
                 page.h1("Dataset " + name)
                 page.p("Configuration:")
                 with page.tag("pre"):
-                    for k, v in sorted(self.handler.server.remote_cfg[name].items()):
+                    for k, v in sorted(cfg.items()):
                         print("{k} = {v}".format(k=html.escape(k), v=html.escape(v)), file=page.out)
                 with page.ul():
                     with page.li(): page.a("/dataset/" + name + "/summary", "Download summary")

--- a/python/arkimet/server/views.py
+++ b/python/arkimet/server/views.py
@@ -9,7 +9,7 @@ from urllib.parse import quote
 from contextlib import contextmanager
 import logging
 import arkimet as arki
-from werkzeug.exceptions import NotFound
+from werkzeug.exceptions import HTTPException, NotFound
 
 
 class ArkiView:
@@ -123,6 +123,8 @@ class ArkiView:
             self.stream()
             if not self.headers_sent:
                 self.send_headers()
+        except HTTPException as e:
+            raise e
         except Exception:
             self.handle_exception()
         self.log_end()
@@ -275,6 +277,8 @@ class TempdirMixin:
                 self.stream()
                 if not self.headers_sent:
                     self.send_headers()
+        except HTTPException as e:
+            raise e
         except Exception:
             self.handle_exception()
         finally:


### PR DESCRIPTION
Fix #81 

1. `ArkiDatasetIndex` raise `werkzeug.exceptions.NotFound` when the dataset doesn't exist instead of `KeyError`
2. The HTTP status code is the `code` attribute of the exception if found (default: 500). It's a duck typing of  `werkzeug.exceptions.HTTPException`.