### PR TITLE
HTTP authentication

### DIFF
--- a/arki/dataset/http.cc
+++ b/arki/dataset/http.cc
@@ -122,6 +122,8 @@ void Request::perform()
         checked("selecting GET method", curl_easy_setopt(curl, CURLOPT_HTTPGET, 1));
     else
         throw std::runtime_error("requested unsupported HTTP method '" + method + "'");
+    checked("setting HTTP authentication method", curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_ANY));
+    checked("setting netrc usage", curl_easy_setopt(curl, CURLOPT_NETRC, CURL_NETRC_OPTIONAL));
     checked("setting header function", curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, &Request::headerfunc));
     checked("setting header function data", curl_easy_setopt(curl, CURLOPT_WRITEHEADER, this));
     checked("setting write function", curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &Request::writefunc));


### PR DESCRIPTION
Fix #72 

Use [any suitable HTTP auth (`CURLAUTH_ANY`)](https://curl.haxx.se/libcurl/c/CURLOPT_HTTPAUTH.html) and [optional `.netrc` (`CURL_NETRC_OPTIONAL`)](https://curl.haxx.se/libcurl/c/CURLOPT_NETRC.html).

It's a work in progress because I haven't tested it :)