### PR TITLE
Remove `..` from unarchive path

### DIFF
--- a/arki/dataset/archive.cc
+++ b/arki/dataset/archive.cc
@@ -420,7 +420,7 @@ void ArchivesChecker::indexSegment(const std::string& relname, metadata::Collect
 
 void ArchivesChecker::releaseSegment(const std::string& relpath, const std::string& destpath)
 {
-    string path = relpath;
+    string path = utils::str::normpath(relpath);
     string name = poppath(path);
     if (name != "last") throw std::runtime_error(this->name() + ": cannot release segment " + relpath + ": segment is not in last/ archive");
 

--- a/arki/tests/testdata.json
+++ b/arki/tests/testdata.json
@@ -13996,6 +13996,11 @@
  },
  {
   "doc": "",
+  "group": "arki_dataset_segmented_ondisk2",
+  "method": "unarchive_segment_lastonly"
+ },
+ {
+  "doc": "",
   "group": "arki_dataset_segmented_simple_plain",
   "method": "compressed"
  },
@@ -14031,6 +14036,11 @@
  },
  {
   "doc": "",
+  "group": "arki_dataset_segmented_simple_plain",
+  "method": "unarchive_segment_lastonly"
+ },
+ {
+  "doc": "",
   "group": "arki_dataset_segmented_simple_sqlite",
   "method": "compressed"
  },
@@ -14066,6 +14076,11 @@
  },
  {
   "doc": "",
+  "group": "arki_dataset_segmented_simple_sqlite",
+  "method": "unarchive_segment_lastonly"
+ },
+ {
+  "doc": "",
   "group": "arki_dataset_segmented_iseg",
   "method": "compressed"
  },
@@ -14098,6 +14113,11 @@
   "doc": "",
   "group": "arki_dataset_segmented_iseg",
   "method": "unarchive_segment"
+ },
+ {
+  "doc": "",
+  "group": "arki_dataset_segmented_iseg",
+  "method": "unarchive_segment_lastonly"
  },
  {
   "doc": "",


### PR DESCRIPTION
`..` in `--unarchive` path is expanded, to avoid unarchive of segments outside `last` (fix #100)