### PR TITLE
Timerange for generic BUFR only

### DIFF
--- a/conf/scan-bufr/generic.lua
+++ b/conf/scan-bufr/generic.lua
@@ -5,4 +5,5 @@ function scan(msg, md)
     if area then md:set(arki_area.grib(area)) end
     if proddef then md:set(arki_proddef.grib(proddef)) end
     if report then md:set(md.product:addValues{t=report:enqc()}) end
+    md:set(bufr_scan_forecast(msg))
 end

--- a/conf/scan-bufr/pilot.lua
+++ b/conf/scan-bufr/pilot.lua
@@ -3,6 +3,4 @@ function scan(msg, md)
     local proddef = bufr_read_proddef(msg)
     if area then md:set(arki_area.grib(area)) end
     if proddef then md:set(arki_proddef.grib(proddef)) end
-
-    md:set(bufr_scan_forecast(msg))
 end

--- a/conf/scan-bufr/temp.lua
+++ b/conf/scan-bufr/temp.lua
@@ -3,6 +3,4 @@ function scan(msg, md)
     local proddef = bufr_read_proddef(msg)
     if area then md:set(arki_area.grib(area)) end
     if proddef then md:set(arki_proddef.grib(proddef)) end
-
-    md:set(bufr_scan_forecast(msg))
 end

--- a/conf/scan-bufr/temp_ship.lua
+++ b/conf/scan-bufr/temp_ship.lua
@@ -3,6 +3,4 @@ function scan(msg, md)
     local proddef = bufr_read_proddef(msg)
     if area then md:set(arki_area.grib(area)) end
     if proddef then md:set(arki_proddef.grib(proddef)) end
-
-    md:set(bufr_scan_forecast(msg))
 end


### PR DESCRIPTION
A "generic" BUFR is a file with "generic" template and rep_memo different from "temp", "temp_ship", "pilot", etc.

E.g. a BUFR file with "generic" template and rep_memo equals to "temp" is considered a "temp" BUFR and then the timerange is ignored.

After this fix, we should change the rep_memo of the "generic" BUFR with "rep_memo=temp" and rescan the dataset.

Fix #125.