### PR TITLE
Custom rpm macro for archive name (#136)

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -29,13 +29,13 @@ $builddep -y fedora/SPECS/arkimet.spec
 
 if [[ $image =~ ^fedora: || $image =~ ^centos: ]]
 then
-    pkgname=arkimet-$(git describe --abbrev=0 --tags --match='v*' | sed -e 's,^v,,g')
+    pkgname=arkimet-master
     mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
     cp fedora/SPECS/arkimet.spec ~/rpmbuild/SPECS/arkimet.spec
     cp fedora/SOURCES/* ~/rpmbuild/SOURCES/
     git archive --prefix=$pkgname/ --format=tar HEAD | gzip -c > ~/rpmbuild/SOURCES/$pkgname.tar.gz
-    rpmbuild -ba ~/rpmbuild/SPECS/arkimet.spec
-    find ~/rpmbuild/{RPMS,SRPMS}/ -name "${pkgname}*rpm" -exec cp -v {} . \;
+    rpmbuild -ba --define "_srcarchivename $pkgname" ~/rpmbuild/SPECS/arkimet.spec
+    find ~/rpmbuild/{RPMS,SRPMS}/ -name "*rpm" -exec cp -v {} . \;
     # TODO upload ${pkgname}*.rpm to github release on deploy stage
 else
     autoreconf -ifv

--- a/fedora/SPECS/arkimet.spec
+++ b/fedora/SPECS/arkimet.spec
@@ -1,3 +1,6 @@
+# Note: define _srcarchivename in Travis build only.
+%{!?_srcarchivename: %global _srcarchivename %{name}-%{version}-%{release}}
+
 Summary: Archive for weather information
 Name: arkimet
 Version: 1.6
@@ -5,11 +8,10 @@ Release: 3
 License: GPL
 Group: Applications/Meteo
 URL: https://github.com/arpa-simc/%{name}
-Source0: https://github.com/arpa-simc/%{name}/archive/v%{version}-%{release}.tar.gz#/%{name}-%{version}-%{release}.tar.gz
+Source0: https://github.com/arpa-simc/%{name}/archive/v%{version}-%{release}.tar.gz#/%{_srcarchivename}.tar.gz
 Source1: https://github.com/arpa-simc/%{name}/raw/v%{version}-%{release}/fedora/SOURCES/%{name}.service
 Source2: https://github.com/arpa-simc/%{name}/raw/v%{version}-%{release}/fedora/SOURCES/%{name}.sysconfig
 Source3: https://github.com/arpa-simc/%{name}/raw/v%{version}-%{release}/fedora/SOURCES/%{name}-logrotate.conf
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 
 # On fedora, we don't need systemd to build. But we do on centos.
 %{?el7:BuildRequires: systemd}
@@ -65,7 +67,7 @@ Requires: libdballe-devel, %{grib_sw}-devel, libwreport-devel, %{python3_vers}-d
  Arkimet developement library
 
 %prep
-%setup -q -n %{name}-%{version}-%{release}
+%setup -q -n %{_srcarchivename}
 sh autogen.sh
 
 %build


### PR DESCRIPTION
`_srcarchivename` will be overidden in Travis build to avoid the dependency
from the latest tag (which could be unavailable is older than 50 commits).

Fix #136 