### PR TITLE
Autoconf check for nose program (fix #196)

### DIFF
--- a/arki/runtest
+++ b/arki/runtest
@@ -5,18 +5,7 @@ PYTHON=${PYTHON:-python3}
 
 if [ "$1" = "NOSE" ]
 then
-    # Try to find out what is the name of the nose executable today (sigh)
-    PYTHON_VERSION="$($PYTHON -c 'import sys; print("{0}.{1}".format(*sys.version_info[:]))')"
-    NOSE=""
-    for cand in nose2-3 nosetests-3.6 nosetests-3.5 nosetests-3.4 nosetests-3.3 nosetests-${PYTHON_VERSION}
-    do
-        NOSE=`which $cand 2>/dev/null` && break
-    done
-    if [ -z "$NOSE" ]
-    then
-        echo "python3-nose not found" >&2
-        exit 1
-    fi
+    NOSE="${NOSE:-nose}"
     CMD="$NOSE -s `pwd`"
     DEBUG_CMD="$PYTHON $NOSE -s `pwd`"
 else

--- a/configure.ac
+++ b/configure.ac
@@ -340,7 +340,11 @@ then
     AC_DEFINE(HAVE_PYTHON, 1, [Have Python bindings])
     AX_PYTHON_MODULE(werkzeug, yes)
     AX_PYTHON_MODULE(setproctitle, yes)
-    AX_PYTHON_MODULE(nose, yes)
+    AC_CHECK_PROGS(NOSE, [nose2-3 nosetests-3.6 nosetests-3.5 nosetests-3.4 nosetests-3.3 nosetests-$PYTHON_VERSION])
+    if test x$NOSE = x
+    then
+        AC_MSG_ERROR([Python nose not found])
+    fi
     AX_PYTHON_MODULE(jinja2, yes)
     AX_PYTHON_MODULE(wreport, yes)
     AX_PYTHON_MODULE(dballe, yes)

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -141,6 +141,6 @@ EXTRA_DIST = \
 #    $(arkimet_python_tests)
 
 check-local: _arkimet.so
-	PYTHON="$(PYTHON)" $(TESTS_ENVIRONMENT) NOSE
+	PYTHON="$(PYTHON)" NOSE="@NOSE@" $(TESTS_ENVIRONMENT) NOSE
 
 #CLEANFILES = python-arkimet.rst python-arkimet.html


### PR DESCRIPTION
`AX_PYTHON_MODULE(nose, yes)` checks for the Python module, but Arkimet use the node command only, then we can check for the latter in `configure.ac`.