### PR TITLE
Update grib2 table version

### DIFF
--- a/python/arkimet/formatter/eccodes.py
+++ b/python/arkimet/formatter/eccodes.py
@@ -109,7 +109,7 @@ class GribTable:
 
     @classmethod
     def get_grib2_table_prefix(cls, centre, table_version, local_table_version):
-        default_table_version = 4
+        default_table_version = 15
 
         if table_version is None or table_version == 255:
             table_version = default_table_version


### PR DESCRIPTION
Could we quickly update the grib2 default table version at least to 15 (4 is 16 years old), as for discussion in #321, waiting for a more stable solution?